### PR TITLE
normalize the markdownify'd content summary

### DIFF
--- a/generate_active_daily/__main__.py
+++ b/generate_active_daily/__main__.py
@@ -17,6 +17,7 @@ import asyncio
 import textwrap
 import json
 import sys
+import unicodedata
 
 from datetime import datetime
 from pathlib import Path
@@ -186,7 +187,9 @@ initial_python_code = next(
 )
 
 # our docstring is pretty simple, everything before the examples, the number and the title
-docstring_ = markdownify(content_before_example)
+# see #4, potentially an edge case, normalize \xa0 (&nbsp;) to ' ' using NFKC
+# NFKC = normal form compatibility decomposition followed by canonical composition
+docstring_ = unicodedata.normalize("NFKC", markdownify(content_before_example))
 
 lines_ = filter(lambda x: x, docstring_.splitlines())
 wrapped_docstring = (


### PR DESCRIPTION
Closes #4

This is a living repo, where each solution boilerplate reflects the state of the build process unless it's back-filled

This should be a valid attempt to resolve any future possible `\xa0` slipping in. It could also be the result of 3.11 & `markdownify`, but it should be harmless to keep this with the content we're dealing with. 

Which should only be plain text in normal characters (unless it's part of the challenge) and spans with **bold**, _italic_, and `code`.

