### PR TITLE
append a `<p>&nbsp;</p>` which is dropped

### DIFF
--- a/generate_active_daily/__main__.py
+++ b/generate_active_daily/__main__.py
@@ -251,8 +251,13 @@ html_summary = results["activeDailyCodingChallengeQuestion"]["question"]["conten
 soup = BeautifulSoup(html_summary, "html.parser")
 example_starts = soup.find("p", string="\xa0")
 
-CONTENT_BEFORE_EXAMPLE = "".join(
-    str(content) for content in soup.contents[: soup.contents.index(example_starts)]
+CONTENT_BEFORE_EXAMPLE = (
+    "".join(
+        str(content) for content in soup.contents[: soup.contents.index(example_starts)]
+    )
+    # See #31, since we're splitting at `\xa0` (`&nbsp;`) we'll add it here to ensure
+    # docstrings end the way we want them to be stylized.
+    + "<p>&nbsp;</p>"
 )
 
 


### PR DESCRIPTION
Closes #31

append a literal `<p>&nbsp;</p>` which ensures our docstring content matches our preferred styling

the `\xa0` (`&nbsp;`) is dropped during our `content | examples` split, this adds it back