### PR TITLE
Re-apply pre-commit autofix label after any daily PR push

### DIFF
--- a/.github/workflows/reapply_precommit_autofix_label.yml
+++ b/.github/workflows/reapply_precommit_autofix_label.yml
@@ -12,11 +12,7 @@ jobs:
   reapply-label:
     if: >
       contains(github.event.pull_request.labels.*.name, 'daily-boilerplate') &&
-      (
-        github.actor == 'Copilot' ||
-        github.actor == 'github-copilot[bot]' ||
-        endsWith(github.actor, '[bot]') && github.actor != 'pre-commit-ci[bot]'
-      )
+      github.actor != 'pre-commit-ci[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Re-add pre-commit.ci autofix label


### PR DESCRIPTION
After Copilot was removed, solution commits will come from yyolk/Grok rather than a bot.

This updates `reapply_precommit_autofix_label.yml` so it re-adds `pre-commit.ci autofix` on any synchronize of a `daily-boilerplate` PR except `pre-commit-ci[bot]` (to avoid a loop).

Not a daily solution PR.