### PR TITLE
Do not fail codified-solution-check on pull_request before benchmarks

### DIFF
--- a/.github/workflows/check_pr_codified_solution.yml
+++ b/.github/workflows/check_pr_codified_solution.yml
@@ -134,27 +134,6 @@ jobs:
             }
           }
 
-          if (!pr.auto_merge) {
-            try {
-              await github.graphql(
-                `mutation($pullRequestId: ID!) {
-                  enablePullRequestAutoMerge(input: {pullRequestId: $pullRequestId, mergeMethod: SQUASH}) {
-                    pullRequest {
-                      id
-                    }
-                  }
-                }`,
-                {pullRequestId: pr.node_id}
-              );
-              core.info("Enabled squash auto-merge for daily PR.");
-            } catch (error) {
-              if (!isPermissionError(error)) {
-                throw error;
-              }
-              core.warning("Skipping auto-merge enablement due to token permissions.");
-            }
-          }
-
           const [issueComments, reviews, reviewComments] = await Promise.all([
             github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
@@ -183,12 +162,41 @@ jobs:
           );
 
           if (!hasPerformanceComment) {
+            // pull_request runs must succeed so the required job name is not stuck failed.
+            // Auto-merge is only enabled after the benchmark comment exists.
+            if (context.eventName === "pull_request") {
+              core.warning(
+                "No @yyolk performance comment yet. Leaving auto-merge disabled until one is posted."
+              );
+              return;
+            }
             core.setFailed(
               "Expected a @yyolk PR/review comment containing both runtime (`ms`) and memory (`mb`) benchmark figures."
             );
             return;
-          } else {
-            core.info("Found @yyolk performance lines in PR/review comments.");
+          }
+
+          core.info("Found @yyolk performance lines in PR/review comments.");
+
+          if (!pr.auto_merge) {
+            try {
+              await github.graphql(
+                `mutation($pullRequestId: ID!) {
+                  enablePullRequestAutoMerge(input: {pullRequestId: $pullRequestId, mergeMethod: SQUASH}) {
+                    pullRequest {
+                      id
+                    }
+                  }
+                }`,
+                {pullRequestId: pr.node_id}
+              );
+              core.info("Enabled squash auto-merge for daily PR.");
+            } catch (error) {
+              if (!isPermissionError(error)) {
+                throw error;
+              }
+              core.warning("Skipping auto-merge enablement due to token permissions.");
+            }
           }
     - name: Checkout repository for local actions
       if: ${{ github.event_name == 'pull_request' && always() && contains(github.event.pull_request.labels.*.name, 'daily-boilerplate') && github.event.action != 'ready_for_review' }}


### PR DESCRIPTION
Branch protection can only require the job name `codified-solution-check`. GitHub still records separate runs for `pull_request` vs `pull_request_review`.

The `pull_request` run was failing before the benchmark comment existed, and that failed required check stayed red even after the review run passed.

Changes:
- On `pull_request` events, missing performance lines is a warning + success (so the required check is not stuck failed).
- Auto-merge is enabled only after a `@yyolk` performance comment/review exists.
- `issue_comment` / `pull_request_review` still hard-fail if the numbers are missing after those events.

Not a daily solution PR.