### PR TITLE
Don't skip daily check when the boilerplate label races opened

### DIFF
--- a/.github/workflows/check_pr_codified_solution.yml
+++ b/.github/workflows/check_pr_codified_solution.yml
@@ -7,6 +7,7 @@ on:
     - synchronize
     - reopened
     - edited
+    - labeled
     - ready_for_review
   issue_comment:
     types:
@@ -103,9 +104,21 @@ jobs:
             return;
           }
 
-          const hasDailyLabel = pr.labels.some((label) => label.name === "daily-boilerplate");
+          const isDailyTitle = /^\\d{8}$/.test(String(pr.title ?? "").trim());
+          let hasDailyLabel = (pr.labels ?? []).some((label) => label.name === "daily-boilerplate");
 
-          if (!hasDailyLabel) {
+          // opened can race the --label on gh pr create; refetch before giving up.
+          if (!hasDailyLabel && !isDailyTitle) {
+            const {data} = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number
+            });
+            pr = data;
+            hasDailyLabel = (pr.labels ?? []).some((label) => label.name === "daily-boilerplate");
+          }
+
+          if (!hasDailyLabel && !isDailyTitle && !/^\\d{8}$/.test(String(pr.title ?? "").trim())) {
             core.info("Skipping check for non-daily-boilerplate PR.");
             return;
           }
@@ -199,10 +212,10 @@ jobs:
             }
           }
     - name: Checkout repository for local actions
-      if: ${{ github.event_name == 'pull_request' && always() && contains(github.event.pull_request.labels.*.name, 'daily-boilerplate') && github.event.action != 'ready_for_review' }}
+      if: ${{ github.event_name == 'pull_request' && always() && (contains(github.event.pull_request.labels.*.name, 'daily-boilerplate') || github.event.action == 'labeled') && github.event.action != 'ready_for_review' }}
       uses: actions/checkout@v7
     - name: Notify daily PR status
-      if: ${{ github.event_name == 'pull_request' && always() && contains(github.event.pull_request.labels.*.name, 'daily-boilerplate') && github.event.action != 'ready_for_review' }}
+      if: ${{ github.event_name == 'pull_request' && always() && (contains(github.event.pull_request.labels.*.name, 'daily-boilerplate') || github.event.action == 'labeled') && github.event.action != 'ready_for_review' }}
       uses: ./.github/actions/notify-pushover
       with:
         message: >-


### PR DESCRIPTION
Today's daily #272 stayed draft because `codified-solution-check` ran on `opened` before `daily-boilerplate` was on the payload:

`Skipping check for non-daily-boilerplate PR.`

The solver trigger is `pr_opened` (ready / marked ready), so it never fired.

This change:
- listens for `labeled`
- treats a `YYYYMMDD` title as daily even without the label
- refetches the PR when the opened payload has no daily label yet

Not a daily solution PR.